### PR TITLE
cimfs: Add Offline registry API wrappers and export constants

### DIFF
--- a/computestorage/helpers.go
+++ b/computestorage/helpers.go
@@ -16,7 +16,9 @@ import (
 	"github.com/Microsoft/hcsshim/internal/security"
 )
 
-const defaultVHDXBlockSizeInMB = 1
+const (
+	DefaultVHDXBlockSizeInMB = 1
+)
 
 // SetupContainerBaseLayer is a helper to setup a containers scratch. It
 // will create and format the vhdx's inside and the size is configurable with the sizeInGB
@@ -64,7 +66,7 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 		Version: 2,
 		Version2: vhd.CreateVersion2{
 			MaximumSize:      sizeInGB * memory.GiB,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
+			BlockSizeInBytes: DefaultVHDXBlockSizeInMB * memory.MiB,
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
@@ -99,7 +101,7 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 	}
 	// Create the differencing disk that will be what's copied for the final rw layer
 	// for a container.
-	if err = vhd.CreateDiffVhd(diffVhdPath, baseVhdPath, defaultVHDXBlockSizeInMB); err != nil {
+	if err = vhd.CreateDiffVhd(diffVhdPath, baseVhdPath, DefaultVHDXBlockSizeInMB); err != nil {
 		return errors.Wrap(err, "failed to create differencing disk")
 	}
 
@@ -140,7 +142,7 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 		Version: 2,
 		Version2: vhd.CreateVersion2{
 			MaximumSize:      sizeInGB * memory.GiB,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
+			BlockSizeInBytes: DefaultVHDXBlockSizeInMB * memory.MiB,
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
@@ -183,7 +185,7 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 
 	// Create the differencing disk that will be what's copied for the final rw layer
 	// for a container.
-	if err = vhd.CreateDiffVhd(diffVhdPath, baseVhdPath, defaultVHDXBlockSizeInMB); err != nil {
+	if err = vhd.CreateDiffVhd(diffVhdPath, baseVhdPath, DefaultVHDXBlockSizeInMB); err != nil {
 		return errors.Wrap(err, "failed to create differencing disk")
 	}
 

--- a/internal/wclayer/baselayerreader.go
+++ b/internal/wclayer/baselayerreader.go
@@ -72,8 +72,8 @@ func (r *baseLayerReader) walkUntilCancelled() error {
 		return err
 	}
 
-	utilityVMAbsPath := filepath.Join(r.root, utilityVMPath)
-	utilityVMFilesAbsPath := filepath.Join(r.root, utilityVMFilesPath)
+	utilityVMAbsPath := filepath.Join(r.root, UtilityVMPath)
+	utilityVMFilesAbsPath := filepath.Join(r.root, UtilityVMFilesPath)
 
 	// Ignore a UtilityVM without Files, that's not _really_ a UtiltyVM
 	if _, err = os.Lstat(utilityVMFilesAbsPath); err != nil {

--- a/internal/wclayer/converttobaselayer.go
+++ b/internal/wclayer/converttobaselayer.go
@@ -72,7 +72,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 		}
 	}
 
-	stat, err := safefile.LstatRelative(utilityVMFilesPath, root)
+	stat, err := safefile.LstatRelative(UtilityVMFilesPath, root)
 
 	if os.IsNotExist(err) {
 		return false, nil
@@ -83,7 +83,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 	}
 
 	if !stat.Mode().IsDir() {
-		fullPath := filepath.Join(root.Name(), utilityVMFilesPath)
+		fullPath := filepath.Join(root.Name(), UtilityVMFilesPath)
 		return false, errors.Errorf("%s has unexpected file mode %s", fullPath, stat.Mode().String())
 	}
 
@@ -92,7 +92,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 	// Just check that this exists as a regular file. If it exists but is not a valid registry hive,
 	// ProcessUtilityVMImage will complain:
 	// "The registry could not read in, or write out, or flush, one of the files that contain the system's image of the registry."
-	bcdPath := filepath.Join(utilityVMFilesPath, bcdRelativePath)
+	bcdPath := filepath.Join(UtilityVMFilesPath, bcdRelativePath)
 
 	stat, err = safefile.LstatRelative(bcdPath, root)
 	if err != nil {
@@ -122,12 +122,12 @@ func convertToBaseLayer(ctx context.Context, root *os.File) error {
 		return nil
 	}
 
-	err = safefile.EnsureNotReparsePointRelative(utilityVMPath, root)
+	err = safefile.EnsureNotReparsePointRelative(UtilityVMPath, root)
 	if err != nil {
 		return err
 	}
 
-	utilityVMPath := filepath.Join(root.Name(), utilityVMPath)
+	utilityVMPath := filepath.Join(root.Name(), UtilityVMPath)
 	return ProcessUtilityVMImage(ctx, utilityVMPath)
 }
 

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -29,10 +29,19 @@ var mutatedUtilityVMFiles = map[string]bool{
 }
 
 const (
-	filesPath          = `Files`
-	hivesPath          = `Hives`
-	utilityVMPath      = `UtilityVM`
-	utilityVMFilesPath = `UtilityVM\Files`
+	filesPath           = `Files`
+	HivesPath           = `Hives`
+	UtilityVMPath       = `UtilityVM`
+	UtilityVMFilesPath  = `UtilityVM\Files`
+	RegFilesPath        = `Files\Windows\System32\config`
+	BcdFilePath         = `UtilityVM\Files\EFI\Microsoft\Boot\BCD`
+	BootMgrFilePath     = `UtilityVM\Files\EFI\Microsoft\Boot\bootmgfw.efi`
+	ContainerBaseVhd    = `blank-base.vhdx`
+	ContainerScratchVhd = `blank.vhdx`
+	UtilityVMBaseVhd    = `SystemTemplateBase.vhdx`
+	UtilityVMScratchVhd = `SystemTemplate.vhdx`
+	LayoutFileName      = `layout`
+	UvmBuildFileName    = `uvmbuildversion`
 )
 
 func openFileOrDir(path string, mode uint32, createDisposition uint32) (file *os.File, err error) {
@@ -243,11 +252,11 @@ func (r *legacyLayerReader) Next() (path string, size int64, fileInfo *winio.Fil
 	if !hasPathPrefix(path, filesPath) {
 		size = fe.fi.Size()
 		r.backupReader = winio.NewBackupFileReader(f, false)
-		if path == hivesPath || path == filesPath {
+		if path == HivesPath || path == filesPath {
 			// The Hives directory has a non-deterministic file time because of the
 			// nature of the import process. Use the times from System_Delta.
 			var g *os.File
-			g, err = os.Open(filepath.Join(r.root, hivesPath, `System_Delta`))
+			g, err = os.Open(filepath.Join(r.root, HivesPath, `System_Delta`))
 			if err != nil {
 				return
 			}
@@ -409,7 +418,7 @@ func (w *legacyLayerWriter) CloseRoots() {
 
 func (w *legacyLayerWriter) initUtilityVM() error {
 	if !w.HasUtilityVM {
-		err := safefile.MkdirRelative(utilityVMPath, w.destRoot)
+		err := safefile.MkdirRelative(UtilityVMPath, w.destRoot)
 		if err != nil {
 			return err
 		}
@@ -417,7 +426,7 @@ func (w *legacyLayerWriter) initUtilityVM() error {
 		// clone the utility VM from the parent layer into this layer. Use hard
 		// links to avoid unnecessary copying, since most of the files are
 		// immutable.
-		err = cloneTree(w.parentRoots[0], w.destRoot, utilityVMFilesPath, mutatedUtilityVMFiles)
+		err = cloneTree(w.parentRoots[0], w.destRoot, UtilityVMFilesPath, mutatedUtilityVMFiles)
 		if err != nil {
 			return fmt.Errorf("cloning the parent utility VM image failed: %s", err)
 		}
@@ -592,7 +601,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		return err
 	}
 
-	if name == utilityVMPath {
+	if name == UtilityVMPath {
 		return w.initUtilityVM()
 	}
 
@@ -601,11 +610,11 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 	}
 
 	name = filepath.Clean(name)
-	if hasPathPrefix(name, utilityVMPath) {
+	if hasPathPrefix(name, UtilityVMPath) {
 		if !w.HasUtilityVM {
 			return errors.New("missing UtilityVM directory")
 		}
-		if !hasPathPrefix(name, utilityVMFilesPath) && name != utilityVMFilesPath {
+		if !hasPathPrefix(name, UtilityVMFilesPath) && name != UtilityVMFilesPath {
 			return errors.New("invalid UtilityVM layer")
 		}
 		createDisposition := uint32(winapi.FILE_OPEN)
@@ -699,7 +708,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		return err
 	}
 
-	if hasPathPrefix(name, hivesPath) {
+	if hasPathPrefix(name, HivesPath) {
 		w.backupWriter = winio.NewBackupFileWriter(f, false)
 		w.bufWriter.Reset(w.backupWriter)
 	} else {
@@ -731,14 +740,14 @@ func (w *legacyLayerWriter) AddLink(name string, target string) error {
 		// Look for cross-layer hard link targets in the parent layers, since
 		// nothing is in the destination path yet.
 		roots = w.parentRoots
-	} else if hasPathPrefix(target, utilityVMFilesPath) {
+	} else if hasPathPrefix(target, UtilityVMFilesPath) {
 		// Since the utility VM is fully cloned into the destination path
 		// already, look for cross-layer hard link targets directly in the
 		// destination path.
 		roots = []*os.File{w.destRoot}
 	}
 
-	if roots == nil || (!hasPathPrefix(name, filesPath) && !hasPathPrefix(name, utilityVMFilesPath)) {
+	if roots == nil || (!hasPathPrefix(name, filesPath) && !hasPathPrefix(name, UtilityVMFilesPath)) {
 		return errors.New("invalid hard link in layer")
 	}
 
@@ -777,7 +786,7 @@ func (w *legacyLayerWriter) Remove(name string) error {
 	name = filepath.Clean(name)
 	if hasPathPrefix(name, filesPath) {
 		w.Tombstones = append(w.Tombstones, name)
-	} else if hasPathPrefix(name, utilityVMFilesPath) {
+	} else if hasPathPrefix(name, UtilityVMFilesPath) {
 		err := w.initUtilityVM()
 		if err != nil {
 			return err

--- a/internal/winapi/offlinereg.go
+++ b/internal/winapi/offlinereg.go
@@ -1,0 +1,36 @@
+package winapi
+
+// Offline registry management API
+
+type OrHKey uintptr
+
+type RegType uint32
+
+const (
+	// Registry value types: https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
+	REG_TYPE_NONE                       RegType = 0
+	REG_TYPE_SZ                         RegType = 1
+	REG_TYPE_EXPAND_SZ                  RegType = 2
+	REG_TYPE_BINARY                     RegType = 3
+	REG_TYPE_DWORD                      RegType = 4
+	REG_TYPE_DWORD_LITTLE_ENDIAN        RegType = 4
+	REG_TYPE_DWORD_BIG_ENDIAN           RegType = 5
+	REG_TYPE_LINK                       RegType = 6
+	REG_TYPE_MULTI_SZ                   RegType = 7
+	REG_TYPE_RESOURCE_LIST              RegType = 8
+	REG_TYPE_FULL_RESOURCE_DESCRIPTOR   RegType = 9
+	REG_TYPE_RESOURCE_REQUIREMENTS_LIST RegType = 10
+	REG_TYPE_QWORD                      RegType = 11
+	REG_TYPE_QWORD_LITTLE_ENDIAN        RegType = 11
+)
+
+//sys OrMergeHives(hiveHandles []OrHKey, result *OrHKey) (win32err error) = offreg.ORMergeHives
+//sys OrOpenHive(hivePath string, result *OrHKey) (win32err error) = offreg.OROpenHive
+//sys OrCloseHive(handle OrHKey) (win32err error) = offreg.ORCloseHive
+//sys OrSaveHive(handle OrHKey, hivePath string, osMajorVersion uint32, osMinorVersion uint32) (win32err error) = offreg.ORSaveHive
+//sys OrOpenKey(handle OrHKey, subKey string, result *OrHKey) (win32err error) = offreg.OROpenKey
+//sys OrCloseKey(handle OrHKey) (win32err error) = offreg.ORCloseKey
+//sys OrCreateKey(handle OrHKey, subKey string, class uintptr, options uint32, securityDescriptor uintptr, result *OrHKey, disposition *uint32) (win32err error) = offreg.ORCreateKey
+//sys OrDeleteKey(handle OrHKey, subKey string) (win32err error) = offreg.ORDeleteKey
+//sys OrGetValue(handle OrHKey, subKey string, value string, valueType *uint32, data *byte, dataLen *uint32) (win32err error) = offreg.ORGetValue
+//sys OrSetValue(handle OrHKey, valueName string, valueType uint32, data *byte, dataLen uint32) (win32err error) = offreg.ORSetValue

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -96,8 +96,16 @@ var (
 	procNtSetInformationFile                   = modntdll.NewProc("NtSetInformationFile")
 	procRtlNtStatusToDosError                  = modntdll.NewProc("RtlNtStatusToDosError")
 	procORCloseHive                            = modoffreg.NewProc("ORCloseHive")
+	procORCloseKey                             = modoffreg.NewProc("ORCloseKey")
 	procORCreateHive                           = modoffreg.NewProc("ORCreateHive")
+	procORCreateKey                            = modoffreg.NewProc("ORCreateKey")
+	procORDeleteKey                            = modoffreg.NewProc("ORDeleteKey")
+	procORGetValue                             = modoffreg.NewProc("ORGetValue")
+	procORMergeHives                           = modoffreg.NewProc("ORMergeHives")
+	procOROpenHive                             = modoffreg.NewProc("OROpenHive")
+	procOROpenKey                              = modoffreg.NewProc("OROpenKey")
 	procORSaveHive                             = modoffreg.NewProc("ORSaveHive")
+	procORSetValue                             = modoffreg.NewProc("ORSetValue")
 )
 
 func LogonUser(username *uint16, domain *uint16, password *uint16, logonType uint32, logonProvider uint32, token *windows.Token) (err error) {
@@ -622,6 +630,14 @@ func RtlNtStatusToDosError(status uint32) (winerr error) {
 	return
 }
 
+func OrCloseHive(handle OrHKey) (win32err error) {
+	r0, _, _ := syscall.Syscall(procORCloseHive.Addr(), 1, uintptr(handle), 0, 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
 func ORCloseHive(key syscall.Handle) (regerrno error) {
 	r0, _, _ := syscall.Syscall(procORCloseHive.Addr(), 1, uintptr(key), 0, 0)
 	if r0 != 0 {
@@ -630,10 +646,137 @@ func ORCloseHive(key syscall.Handle) (regerrno error) {
 	return
 }
 
+func OrCloseKey(handle OrHKey) (win32err error) {
+	r0, _, _ := syscall.Syscall(procORCloseKey.Addr(), 1, uintptr(handle), 0, 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
 func ORCreateHive(key *syscall.Handle) (regerrno error) {
 	r0, _, _ := syscall.Syscall(procORCreateHive.Addr(), 1, uintptr(unsafe.Pointer(key)), 0, 0)
 	if r0 != 0 {
 		regerrno = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrCreateKey(handle OrHKey, subKey string, class uintptr, options uint32, securityDescriptor uintptr, result *OrHKey, disposition *uint32) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(subKey)
+	if win32err != nil {
+		return
+	}
+	return _OrCreateKey(handle, _p0, class, options, securityDescriptor, result, disposition)
+}
+
+func _OrCreateKey(handle OrHKey, subKey *uint16, class uintptr, options uint32, securityDescriptor uintptr, result *OrHKey, disposition *uint32) (win32err error) {
+	r0, _, _ := syscall.Syscall9(procORCreateKey.Addr(), 7, uintptr(handle), uintptr(unsafe.Pointer(subKey)), uintptr(class), uintptr(options), uintptr(securityDescriptor), uintptr(unsafe.Pointer(result)), uintptr(unsafe.Pointer(disposition)), 0, 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrDeleteKey(handle OrHKey, subKey string) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(subKey)
+	if win32err != nil {
+		return
+	}
+	return _OrDeleteKey(handle, _p0)
+}
+
+func _OrDeleteKey(handle OrHKey, subKey *uint16) (win32err error) {
+	r0, _, _ := syscall.Syscall(procORDeleteKey.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(subKey)), 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrGetValue(handle OrHKey, subKey string, value string, valueType *uint32, data *byte, dataLen *uint32) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(subKey)
+	if win32err != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, win32err = syscall.UTF16PtrFromString(value)
+	if win32err != nil {
+		return
+	}
+	return _OrGetValue(handle, _p0, _p1, valueType, data, dataLen)
+}
+
+func _OrGetValue(handle OrHKey, subKey *uint16, value *uint16, valueType *uint32, data *byte, dataLen *uint32) (win32err error) {
+	r0, _, _ := syscall.Syscall6(procORGetValue.Addr(), 6, uintptr(handle), uintptr(unsafe.Pointer(subKey)), uintptr(unsafe.Pointer(value)), uintptr(unsafe.Pointer(valueType)), uintptr(unsafe.Pointer(data)), uintptr(unsafe.Pointer(dataLen)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrMergeHives(hiveHandles []OrHKey, result *OrHKey) (win32err error) {
+	var _p0 *OrHKey
+	if len(hiveHandles) > 0 {
+		_p0 = &hiveHandles[0]
+	}
+	r0, _, _ := syscall.Syscall(procORMergeHives.Addr(), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(hiveHandles)), uintptr(unsafe.Pointer(result)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrOpenHive(hivePath string, result *OrHKey) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(hivePath)
+	if win32err != nil {
+		return
+	}
+	return _OrOpenHive(_p0, result)
+}
+
+func _OrOpenHive(hivePath *uint16, result *OrHKey) (win32err error) {
+	r0, _, _ := syscall.Syscall(procOROpenHive.Addr(), 2, uintptr(unsafe.Pointer(hivePath)), uintptr(unsafe.Pointer(result)), 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrOpenKey(handle OrHKey, subKey string, result *OrHKey) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(subKey)
+	if win32err != nil {
+		return
+	}
+	return _OrOpenKey(handle, _p0, result)
+}
+
+func _OrOpenKey(handle OrHKey, subKey *uint16, result *OrHKey) (win32err error) {
+	r0, _, _ := syscall.Syscall(procOROpenKey.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(subKey)), uintptr(unsafe.Pointer(result)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrSaveHive(handle OrHKey, hivePath string, osMajorVersion uint32, osMinorVersion uint32) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(hivePath)
+	if win32err != nil {
+		return
+	}
+	return _OrSaveHive(handle, _p0, osMajorVersion, osMinorVersion)
+}
+
+func _OrSaveHive(handle OrHKey, hivePath *uint16, osMajorVersion uint32, osMinorVersion uint32) (win32err error) {
+	r0, _, _ := syscall.Syscall6(procORSaveHive.Addr(), 4, uintptr(handle), uintptr(unsafe.Pointer(hivePath)), uintptr(osMajorVersion), uintptr(osMinorVersion), 0, 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }
@@ -651,6 +794,23 @@ func _ORSaveHive(key syscall.Handle, file *uint16, OsMajorVersion uint32, OsMino
 	r0, _, _ := syscall.Syscall6(procORSaveHive.Addr(), 4, uintptr(key), uintptr(unsafe.Pointer(file)), uintptr(OsMajorVersion), uintptr(OsMinorVersion), 0, 0)
 	if r0 != 0 {
 		regerrno = syscall.Errno(r0)
+	}
+	return
+}
+
+func OrSetValue(handle OrHKey, valueName string, valueType uint32, data *byte, dataLen uint32) (win32err error) {
+	var _p0 *uint16
+	_p0, win32err = syscall.UTF16PtrFromString(valueName)
+	if win32err != nil {
+		return
+	}
+	return _OrSetValue(handle, _p0, valueType, data, dataLen)
+}
+
+func _OrSetValue(handle OrHKey, valueName *uint16, valueType uint32, data *byte, dataLen uint32) (win32err error) {
+	r0, _, _ := syscall.Syscall6(procORSetValue.Addr(), 5, uintptr(handle), uintptr(unsafe.Pointer(valueName)), uintptr(valueType), uintptr(unsafe.Pointer(data)), uintptr(dataLen), 0)
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }

--- a/pkg/ociwclayer/export.go
+++ b/pkg/ociwclayer/export.go
@@ -71,7 +71,7 @@ func writeTarFromLayer(ctx context.Context, r wclayer.LayerReader, w io.Writer) 
 		if fileInfo == nil {
 			// Write a whiteout file.
 			hdr := &tar.Header{
-				Name: filepath.ToSlash(filepath.Join(filepath.Dir(name), whiteoutPrefix+filepath.Base(name))),
+				Name: filepath.ToSlash(filepath.Join(filepath.Dir(name), WhiteoutPrefix+filepath.Base(name))),
 			}
 			err := t.WriteHeader(hdr)
 			if err != nil {

--- a/pkg/ociwclayer/import.go
+++ b/pkg/ociwclayer/import.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
 
-const whiteoutPrefix = ".wh."
+const WhiteoutPrefix = ".wh."
 
 var (
 	// mutatedFiles is a list of files that are mutated by the import process
@@ -71,8 +71,8 @@ func writeLayerFromTar(ctx context.Context, r io.Reader, w wclayer.LayerWriter, 
 		}
 
 		base := path.Base(hdr.Name)
-		if strings.HasPrefix(base, whiteoutPrefix) {
-			name := path.Join(path.Dir(hdr.Name), base[len(whiteoutPrefix):])
+		if strings.HasPrefix(base, WhiteoutPrefix) {
+			name := path.Join(path.Dir(hdr.Name), base[len(WhiteoutPrefix):])
 			err = w.Remove(filepath.FromSlash(name))
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
offline registry API is required during CimFS layer import. This commit adds Go wrappers around it.  It also exports some constants from the wclayer package so that those constants can be used by the cim layer package